### PR TITLE
Fix encoding arrays for (NOT) IN queries

### DIFF
--- a/src/Query/Generator/SQL.php
+++ b/src/Query/Generator/SQL.php
@@ -261,11 +261,19 @@ class SQL implements QueryGeneratorInterface
     /**
      * Generate value for where ore field usage
      *
-     * @param float|int|string|null $value
+     * @param float|int|string|array|null $value
      * @return string
      */
-    private function generateValue(float|int|string|null $value): string
+    private function generateValue(float|int|string|null|array $value): string
     {
+        if (is_array($value)) {
+            $values = [];
+            foreach ($value as $v) {
+                $values[] = $this->generateValue($v);
+            }
+            return "(" . implode(", ", $values) . ")";
+        }
+
         if (is_int($value) || is_float($value)) {
             return $value;
         }


### PR DESCRIPTION
When trying to use a where condition, using IN or NOT IN and passing an array, the following Fatal Error occurs:
```
PHP Fatal error:  Uncaught TypeError: Aternos\Model\Query\Generator\SQL::generateValue(): Argument #1 ($value) must be of type string|int|float|null, array given, called in vendor/aternos/model/src/Query/Generator/SQL.php on line 127 and defined in vendor/aternos/model/src/Query/Generator/SQL.php:267
Stack trace:
#0 vendor/aternos/model/src/Query/Generator/SQL.php(127): Aternos\Model\Query\Generator\SQL->generateValue()
#1 vendor/aternos/model/src/Query/Generator/SQL.php(145): Aternos\Model\Query\Generator\SQL->generateWhere()
#2 vendor/aternos/model/src/Query/Generator/SQL.php(88): Aternos\Model\Query\Generator\SQL->generateWhere()
#3 vendor/aternos/model/src/Driver/Mysqli/Mysqli.php(240): Aternos\Model\Query\Generator\SQL->generate()
#4 vendor/aternos/model/src/GenericModel.php(469): Aternos\Model\Driver\Mysqli\Mysqli->query()
```

This PR fixes that issue by generating the correct SQL representation of the array