### PR TITLE
PHP 8.4 compatability: Make parameter types explicitly nullable

### DIFF
--- a/src/Query/Generator/SQL.php
+++ b/src/Query/Generator/SQL.php
@@ -112,7 +112,7 @@ class SQL implements QueryGeneratorInterface
      * @param WhereCondition|WhereGroup|null $where
      * @return string
      */
-    private function generateWhere(Query $query, WhereCondition|WhereGroup $where = null): string
+    private function generateWhere(Query $query, WhereCondition|WhereGroup|null $where = null): string
     {
         if (!$where) {
             $where = $query->getWhere();


### PR DESCRIPTION
In PHP 8.4 implicitly marking parameters as nullable is deprecated. This PR explicitly marks the parameters as nullable by adding a `|null` to the parameter types with a default value of null (`= null`).