### PR TITLE
Throw specific exceptions with common parent class

### DIFF
--- a/src/Driver/Cassandra/Cassandra.php
+++ b/src/Driver/Cassandra/Cassandra.php
@@ -121,14 +121,18 @@ class Cassandra extends Driver implements CRUDAbleInterface, QueryableInterface
      *
      * @param string $query
      * @return Rows
-     * @throws Exception
+     * @throws CassandraModelException if an error occurs while executing the query
      */
     protected function rawQuery(string $query): Rows
     {
         $this->connect();
 
         $statement = new SimpleStatement($query);
-        return $this->connection->execute($statement, null);
+        try {
+            return $this->connection->execute($statement, null);
+        } catch (Exception $e) {
+            throw CassandraModelException::wrapping($e);
+        }
     }
 
     /**
@@ -136,7 +140,7 @@ class Cassandra extends Driver implements CRUDAbleInterface, QueryableInterface
      *
      * @param ModelInterface $model
      * @return bool
-     * @throws Exception
+     * @throws CassandraModelException if an error occurs while executing the query
      */
     public function save(ModelInterface $model): bool
     {
@@ -158,7 +162,7 @@ class Cassandra extends Driver implements CRUDAbleInterface, QueryableInterface
      * @param mixed $id
      * @param ModelInterface|null $model
      * @return ModelInterface|null
-     * @throws Exception
+     * @throws CassandraModelException if an error occurs while executing the query
      */
     public function get(string $modelClass, mixed $id, ?ModelInterface $model = null): ?ModelInterface
     {
@@ -183,7 +187,7 @@ class Cassandra extends Driver implements CRUDAbleInterface, QueryableInterface
      *
      * @param ModelInterface $model
      * @return bool
-     * @throws Exception
+     * @throws CassandraModelException if an error occurs while executing the query
      */
     public function delete(ModelInterface $model): bool
     {
@@ -200,7 +204,7 @@ class Cassandra extends Driver implements CRUDAbleInterface, QueryableInterface
      *
      * @param Query $query
      * @return QueryResult
-     * @throws Exception
+     * @throws CassandraModelException if an error occurs while executing the query
      */
     public function query(Query $query): QueryResult
     {

--- a/src/Driver/Cassandra/CassandraModelException.php
+++ b/src/Driver/Cassandra/CassandraModelException.php
@@ -1,0 +1,20 @@
+<?php /** @noinspection PhpComposerExtensionStubsInspection */
+
+namespace Aternos\Model\Driver\Cassandra;
+
+use Aternos\Model\WrappingModelException;
+use Throwable;
+
+class CassandraModelException extends WrappingModelException
+{
+    /**
+     * Wrap an existing exception into a CassandraModelException
+     * This is used to adapt exceptions from the cassandra extension to a ModelException
+     * @param Throwable $exception
+     * @return static
+     */
+    static function wrapping(Throwable $exception): static
+    {
+        return new self($exception->getMessage(), $exception->getCode(), $exception);
+    }
+}

--- a/src/Driver/Mysqli/MysqlConnectionFailedException.php
+++ b/src/Driver/Mysqli/MysqlConnectionFailedException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Aternos\Model\Driver\Mysqli;
+
+use Throwable;
+
+class MysqlConnectionFailedException extends MysqlException
+{
+    public function __construct(Throwable $previous)
+    {
+        parent::__construct("Could not connect to Mysqli database", $previous?->getCode(), $previous);
+    }
+}

--- a/src/Driver/Mysqli/MysqlException.php
+++ b/src/Driver/Mysqli/MysqlException.php
@@ -1,0 +1,38 @@
+<?php /** @noinspection PhpComposerExtensionStubsInspection */
+
+namespace Aternos\Model\Driver\Mysqli;
+
+use Aternos\Model\ModelException;
+use mysqli;
+use Throwable;
+
+class MysqlException extends ModelException
+{
+    /**
+     * Check if a MySQLi connection has an error and throw an exception if it has
+     * @param mysqli $connection
+     * @return void
+     * @throws MysqlException if the connection has an error
+     */
+    static function checkConnection(mysqli $connection): void
+    {
+        if (mysqli_error($connection)) {
+            throw static::fromConnection($connection);
+        }
+    }
+
+    /**
+     * Create an exception from a MySQLi connection with an error
+     * @param mysqli $connection
+     * @return static
+     */
+    static function fromConnection(mysqli $connection): static
+    {
+        return new self("MySQLi Error #" . mysqli_errno($connection) . ": " . mysqli_error($connection));
+    }
+
+    public function __construct(string $message, int $code = 0, ?Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Driver/Mysqli/Mysqli.php
+++ b/src/Driver/Mysqli/Mysqli.php
@@ -10,9 +10,7 @@ use Aternos\Model\{Driver\Driver,
     Query\Generator\SQL,
     Query\Query,
     Query\QueryResult,
-    Query\UpdateQuery
-};
-use Exception;
+    Query\UpdateQuery};
 use mysqli_result;
 
 /**
@@ -99,15 +97,14 @@ class Mysqli extends Driver implements CRUDAbleInterface, CRUDQueryableInterface
 
     /**
      * Connect to database
-     *
-     * @throws Exception
+     * @throws MysqlConnectionFailedException if connecting to the mysql database fails
      */
     protected function connect(): void
     {
         if (!$this->connection || !@mysqli_ping($this->connection)) {
             $this->connection = mysqli_connect($this->host, $this->username, $this->password, $this->database, $this->port, $this->socket);
             if (!$this->connection) {
-                throw new Exception("Could not connect to Mysqli database. Error: " . mysqli_error($this->connection));
+                throw new MysqlConnectionFailedException(new MysqlException($this->connection));
             }
         }
     }
@@ -117,17 +114,14 @@ class Mysqli extends Driver implements CRUDAbleInterface, CRUDQueryableInterface
      *
      * @param string $query
      * @return bool|mysqli_result
-     * @throws Exception
+     * @throws MysqlConnectionFailedException if connecting to the mysql database fails
+     * @throws MysqlException if a mysql error occurs while executing the query
      */
     protected function rawQuery(string $query): mysqli_result|bool
     {
         $this->connect();
         $result = mysqli_query($this->connection, $query);
-
-        if (mysqli_error($this->connection)) {
-            throw new Exception("MySQLi Error #" . mysqli_errno($this->connection) . ": " . mysqli_error($this->connection));
-        }
-
+        MysqlException::checkConnection($this->connection);
         return $result;
     }
 
@@ -136,7 +130,8 @@ class Mysqli extends Driver implements CRUDAbleInterface, CRUDQueryableInterface
      *
      * @param ModelInterface $model
      * @return bool
-     * @throws Exception
+     * @throws MysqlConnectionFailedException if connecting to the mysql database fails
+     * @throws MysqlException if a mysql error occurs while executing the query
      */
     public function save(ModelInterface $model): bool
     {
@@ -182,7 +177,8 @@ class Mysqli extends Driver implements CRUDAbleInterface, CRUDQueryableInterface
      * @param mixed $id
      * @param ModelInterface|null $model
      * @return ModelInterface|null
-     * @throws Exception
+     * @throws MysqlConnectionFailedException if connecting to the mysql database fails
+     * @throws MysqlException if a mysql error occurs while executing the query
      */
     public function get(string $modelClass, mixed $id, ?ModelInterface $model = null): ?ModelInterface
     {
@@ -208,7 +204,8 @@ class Mysqli extends Driver implements CRUDAbleInterface, CRUDQueryableInterface
      *
      * @param ModelInterface $model
      * @return bool
-     * @throws Exception
+     * @throws MysqlConnectionFailedException if connecting to the mysql database fails
+     * @throws MysqlException if a mysql error occurs while executing the query
      */
     public function delete(ModelInterface $model): bool
     {
@@ -227,7 +224,8 @@ class Mysqli extends Driver implements CRUDAbleInterface, CRUDQueryableInterface
      *
      * @param Query $query
      * @return QueryResult
-     * @throws Exception
+     * @throws MysqlConnectionFailedException if connecting to the mysql database fails
+     * @throws MysqlException if a mysql error occurs while executing the query
      */
     public function query(Query $query): QueryResult
     {

--- a/src/Driver/OpenSearch/Exception/OpenSearchException.php
+++ b/src/Driver/OpenSearch/Exception/OpenSearchException.php
@@ -2,9 +2,9 @@
 
 namespace Aternos\Model\Driver\OpenSearch\Exception;
 
-use Exception;
+use Aternos\Model\ModelException;
 
-class OpenSearchException extends Exception
+class OpenSearchException extends ModelException
 {
 
 }

--- a/src/Driver/OpenSearch/OpenSearchHost.php
+++ b/src/Driver/OpenSearch/OpenSearchHost.php
@@ -40,9 +40,9 @@ class OpenSearchHost
      * @param string $uri
      * @param mixed|null $body
      * @return stdClass
-     * @throws HttpErrorResponseException
-     * @throws HttpTransportException
-     * @throws SerializeException
+     * @throws HttpErrorResponseException If the response status code is not 2xx
+     * @throws HttpTransportException If an error happens while the http client processes the request
+     * @throws SerializeException If an error happens during (de-)serialization
      */
     public function request(string $method, string $uri, mixed $body = null): stdClass
     {
@@ -78,8 +78,9 @@ class OpenSearchHost
     /**
      * @param ResponseInterface $response
      * @return stdClass
-     * @throws HttpTransportException
-     * @throws SerializeException
+     * @throws HttpTransportException If the response body could not be read
+     * @throws HttpTransportException If the response is not JSON
+     * @throws SerializeException If the response body could not be deserialized
      */
     protected function parseResponse(ResponseInterface $response): stdClass
     {
@@ -100,7 +101,7 @@ class OpenSearchHost
     /**
      * @param mixed $data
      * @return string
-     * @throws SerializeException
+     * @throws SerializeException If the data could not be serialized
      */
     protected function serialize(mixed $data): string
     {
@@ -114,7 +115,8 @@ class OpenSearchHost
     /**
      * @param string $data
      * @return stdClass
-     * @throws SerializeException
+     * @throws SerializeException If the data could not be deserialized
+     * @throws SerializeException If the data is not an object
      */
     protected function deserialize(string $data): stdClass
     {

--- a/src/Driver/Redis/RedisModelException.php
+++ b/src/Driver/Redis/RedisModelException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Aternos\Model\Driver\Redis;
+
+use Aternos\Model\WrappingModelException;
+
+class RedisModelException extends WrappingModelException
+{
+
+}

--- a/src/Driver/Test/TestDriver.php
+++ b/src/Driver/Test/TestDriver.php
@@ -9,7 +9,6 @@ use Aternos\Model\ModelInterface;
 use Aternos\Model\ModelRegistry;
 use Aternos\Model\Query\Query;
 use Aternos\Model\Query\QueryResult;
-use Exception;
 
 class TestDriver extends Driver implements CRUDAbleInterface, CRUDQueryableInterface
 {
@@ -94,7 +93,6 @@ class TestDriver extends Driver implements CRUDAbleInterface, CRUDQueryableInter
     /**
      * @param ModelInterface $model
      * @return bool
-     * @throws Exception
      */
     public function delete(ModelInterface $model): bool
     {
@@ -112,7 +110,6 @@ class TestDriver extends Driver implements CRUDAbleInterface, CRUDQueryableInter
      * @param mixed $id
      * @param ModelInterface|null $model
      * @return ModelInterface|null
-     * @throws Exception
      */
     public function get(string $modelClass, mixed $id, ?ModelInterface $model = null): ?ModelInterface
     {
@@ -129,7 +126,6 @@ class TestDriver extends Driver implements CRUDAbleInterface, CRUDQueryableInter
     /**
      * @param ModelInterface $model
      * @return bool
-     * @throws Exception
      */
     public function save(ModelInterface $model): bool
     {
@@ -146,7 +142,6 @@ class TestDriver extends Driver implements CRUDAbleInterface, CRUDQueryableInter
     /**
      * @param Query $query
      * @return QueryResult
-     * @throws Exception
      */
     public function query(Query $query): QueryResult
     {

--- a/src/GenericModel.php
+++ b/src/GenericModel.php
@@ -372,7 +372,7 @@ abstract class GenericModel extends BaseModel
      * @param string $id
      * @param bool $update
      * @return static|null
-     * @throws Exception
+     * @throws ModelException
      */
     public static function get(string $id, bool $update = false): ?static
     {
@@ -560,7 +560,7 @@ abstract class GenericModel extends BaseModel
     }
 
     /**
-     * @throws Exception
+     * @throws ModelException
      */
     public function reload(): static
     {

--- a/src/ModelException.php
+++ b/src/ModelException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Aternos\Model;
+
+use RuntimeException;
+use Throwable;
+
+/**
+ * An exception thrown by the model classes (e.g. while saving or loading models)
+ */
+abstract class ModelException extends RuntimeException
+{
+
+}

--- a/src/WrappingModelException.php
+++ b/src/WrappingModelException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Aternos\Model;
+
+use Throwable;
+
+class WrappingModelException extends ModelException
+{
+    /**
+     * Wrap an existing exception into a ModelException
+     * This is used to adapt exceptions from the driver extensions to a ModelException
+     * @param Throwable $exception
+     * @return static
+     */
+    static function wrapping(Throwable $exception): static
+    {
+        return new static($exception->getMessage(), $exception->getCode(), $exception);
+    }
+
+    final protected function __construct(string $message, int $code = null, ?Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/test/tests/TestDriverTest.php
+++ b/test/tests/TestDriverTest.php
@@ -14,14 +14,10 @@ use Aternos\Model\Query\SumField;
 use Aternos\Model\Query\WhereCondition;
 use Aternos\Model\Query\WhereGroup;
 use Aternos\Model\Test\Src\TestModel;
-use Exception;
 use PHPUnit\Framework\TestCase;
 
 class TestDriverTest extends TestCase
 {
-    /**
-     * @return void
-     */
     protected function setUp(): void
     {
         $testData = "ABCDEFGHIJ";
@@ -34,10 +30,6 @@ class TestDriverTest extends TestCase
         }
     }
 
-    /**
-     * @return void
-     * @throws Exception
-     */
     public function testGet(): void
     {
         $model = TestModel::get("1B");
@@ -56,20 +48,12 @@ class TestDriverTest extends TestCase
         $this->assertNull($model);
     }
 
-    /**
-     * @return void
-     * @throws Exception
-     */
     public function testGetNull(): void
     {
         $model = TestModel::get("DOES_NOT_EXIST");
         $this->assertNull($model);
     }
 
-    /**
-     * @return void
-     * @throws Exception
-     */
     public function testDelete(): void
     {
         $model = TestModel::get("1B");
@@ -77,19 +61,12 @@ class TestDriverTest extends TestCase
         $this->assertNull(TestModel::get("1B"));
     }
 
-    /**
-     * @return void
-     */
     public function testDeleteNull(): void
     {
         $model = new TestModel();
         $this->assertFalse($model->delete());
     }
 
-    /**
-     * @return void
-     * @throws Exception
-     */
     public function testSaveNew(): void
     {
         $model = new TestModel();
@@ -103,10 +80,6 @@ class TestDriverTest extends TestCase
         $this->assertEquals(10, $getModel->number);
     }
 
-    /**
-     * @return void
-     * @throws Exception
-     */
     public function testSaveExisting(): void
     {
         $model = TestModel::get("1B");
@@ -548,10 +521,6 @@ class TestDriverTest extends TestCase
         }
     }
 
-    /**
-     * @return void
-     * @throws Exception
-     */
     public function testUpdate(): void
     {
         TestModel::disableRegistry();
@@ -574,10 +543,6 @@ class TestDriverTest extends TestCase
         $this->assertEquals("C", $model->text);
     }
 
-    /**
-     * @return void
-     * @throws Exception
-     */
     public function testDeleteQuery(): void
     {
         TestModel::disableRegistry();
@@ -599,9 +564,6 @@ class TestDriverTest extends TestCase
         $this->assertNull($model);
     }
 
-    /**
-     * @return void
-     */
     protected function tearDown(): void
     {
         TestModel::clearTestEntries();


### PR DESCRIPTION
This PR replaces the `@throws \Exception` phpdoc tags with individual exception classes that extend `ModelException`.

`ModelException` is also a `RuntimeException` because handling these exceptions should not be expected, and IDEs won't complain when you don't handle them explicitly. 