### PR TITLE
Add getter to check if registry is enabled

### DIFF
--- a/src/GenericModel.php
+++ b/src/GenericModel.php
@@ -337,7 +337,8 @@ abstract class GenericModel extends BaseModel
 
     /**
      * Check if the registry is enabled
-     * @return bool true if the registry is enabled
+     *
+     * @return bool
      */
     public static function isRegistryEnabled(): bool
     {

--- a/src/GenericModel.php
+++ b/src/GenericModel.php
@@ -336,6 +336,15 @@ abstract class GenericModel extends BaseModel
     }
 
     /**
+     * Check if the registry is enabled
+     * @return bool true if the registry is enabled
+     */
+    public static function isRegistryEnabled(): bool
+    {
+        return static::$registry;
+    }
+
+    /**
      *
      *
      * @return void

--- a/test/tests/GenericModelTest.php
+++ b/test/tests/GenericModelTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Aternos\Model\Test\Tests;
+
+use Aternos\Model\GenericModel;
+use PHPUnit\Framework\TestCase;
+
+class GenericModelTest extends TestCase
+{
+    public function testRegistry(): void
+    {
+        $this->assertTrue(GenericModel::isRegistryEnabled());
+        GenericModel::disableRegistry();
+        $this->assertFalse(GenericModel::isRegistryEnabled());
+        GenericModel::enableRegistry();
+        $this->assertTrue(GenericModel::isRegistryEnabled());
+    }
+}


### PR DESCRIPTION
This could be useful to ensure you return the registry to its previous state after temporarily disabling it or to verify that your code doesn't accidentally leave the registry disabled in a test.